### PR TITLE
Add PollingConsumerConfig for cleaner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,134 @@
-# pub-sub-clients
+# Pub/Sub Java Client
+
+This project provides a lightweight Java client for interacting with the
+[pub-sub-service](#) using its HTTP API. The client is built with the standard
+`java.net.http.HttpClient` and requires **Java 17** or newer.
+
+## Building
+
+Execute the following command to compile the project and run the tests:
+
+```bash
+./gradlew build
+```
+
+The compiled JAR will be created under `build/libs/pub-sub-java-client.jar`.
+
+## Using the Client
+
+Include the JAR on your application's classpath or publish it to your package
+repository if desired.
+
+### Creating the Client
+
+```java
+String baseUrl = "http://localhost:8080"; // URL of the pub-sub-service
+PubSubClient client = new PubSubClient(baseUrl);
+```
+
+### Organizations and Topics
+
+```java
+client.createOrganization("my-org");
+Optional<UUID> orgId = client.getOrganizationId("my-org");
+client.createTopic("my-org", "orders");
+```
+
+### Subscriptions
+
+```java
+client.createSubscription("my-org", "orders", "processor");
+Subscription sub = client.getSubscription("my-org", "orders", "processor");
+```
+
+### Publishing Events
+
+```java
+record Message(String message) {}
+
+List<EventPublishRequest<Message>> events = List.of(
+    new EventPublishRequest<>(new Message("alpha")),
+    new EventPublishRequest<>(new Message("bravo"))
+);
+client.publishEvents("my-org", "orders", events);
+```
+
+`EventPublishRequest<T>` accepts any Java object and the client will
+serialize it to JSON before sending it to the service.
+
+### Consuming Events
+
+`consumeEvents` reads the next batch of events and passes them to an
+`EventsHandler`. The handler receives the list of events and a commit function
+to acknowledge processing.
+
+```java
+client.consumeEvents("my-org", "orders", "processor", 100, (events, commit) -> {
+    for (EventResponse e : events) {
+        System.out.println(e.data());
+    }
+
+    // commit once processing is successful
+    List<UUID> ids = events.stream().map(EventResponse::id).toList();
+    commit.apply(ids);
+});
+```
+
+### Periodic Consumption
+
+To continuously poll for events at a fixed interval, use `PollingConsumer`.
+It wraps the client and repeatedly invokes `consumeEvents` in a background
+thread.
+
+```java
+EventsHandler handler = (events, commit) -> {
+    // process events then commit
+    List<UUID> ids = events.stream().map(EventResponse::id).toList();
+    commit.apply(ids);
+};
+
+PollingConsumerConfig cfg = new PollingConsumerConfig(
+        client,
+        "my-org",
+        "orders",
+        "processor",
+        100,
+        1000L, // poll every second
+        handler);
+
+PollingConsumer consumer = new PollingConsumer(cfg);
+consumer.start();
+
+// later when finished
+consumer.close();
+```
+
+### Cleaning Up
+
+```java
+client.deleteSubscription("my-org", "orders", "processor");
+client.deleteTopic("my-org", "orders");
+client.deleteOrganization("my-org");
+```
+
+## API Compatibility
+
+The client implements the endpoints described by the service's OpenAPI
+specification. A shortened excerpt is shown below:
+
+```
+POST /orgs
+GET /orgs/{orgName}
+DELETE /orgs/{orgName}
+POST /{orgName}/topics
+GET /{orgName}/topics/{topicName}
+DELETE /{orgName}/topics/{topicName}
+POST /{orgName}/topics/{topicName}/subscriptions
+GET /{orgName}/topics/{topicName}/subscriptions/{subscriptionName}
+DELETE /{orgName}/topics/{topicName}/subscriptions/{subscriptionName}
+POST /{orgName}/topics/{topicName}/events
+GET  /{orgName}/topics/{topicName}/subscriptions/{subscriptionName}/events
+POST /{orgName}/topics/{topicName}/subscriptions/{subscriptionName}/events
+```
+
+A `RuntimeException` is thrown when the service returns an error status (>=400).

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'pub-sub-java-client'

--- a/src/main/java/com/example/pubsubclient/EventsHandler.java
+++ b/src/main/java/com/example/pubsubclient/EventsHandler.java
@@ -1,0 +1,12 @@
+package com.example.pubsubclient;
+
+import com.example.pubsubclient.model.EventResponse;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface EventsHandler {
+    void handle(List<EventResponse> events, Function<List<UUID>, Integer> commitFn) throws Exception;
+}

--- a/src/main/java/com/example/pubsubclient/PollingConsumer.java
+++ b/src/main/java/com/example/pubsubclient/PollingConsumer.java
@@ -1,0 +1,55 @@
+package com.example.pubsubclient;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Polls the PubSub service at a fixed interval and delegates events to the
+ * provided {@link EventsHandler}. Users can start and stop the polling as
+ * needed.
+ */
+public class PollingConsumer implements AutoCloseable {
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final PollingConsumerConfig config;
+    private ScheduledFuture<?> future;
+
+    public PollingConsumer(PollingConsumerConfig config) {
+        this.config = config;
+    }
+
+    /** Start polling if not already running. */
+    public synchronized void start() {
+        if (future != null && !future.isCancelled()) {
+            return;
+        }
+        future = executor.scheduleAtFixedRate(() -> {
+            try {
+                config.client().consumeEvents(
+                        config.org(),
+                        config.topic(),
+                        config.subscription(),
+                        config.batchSize(),
+                        config.handler());
+            } catch (Exception e) {
+                // Print the error but keep polling
+                e.printStackTrace();
+            }
+        }, 0, config.intervalMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /** Stop polling. */
+    public synchronized void stop() {
+        if (future != null) {
+            future.cancel(false);
+            future = null;
+        }
+    }
+
+    @Override
+    public void close() {
+        stop();
+        executor.shutdownNow();
+    }
+}

--- a/src/main/java/com/example/pubsubclient/PollingConsumerConfig.java
+++ b/src/main/java/com/example/pubsubclient/PollingConsumerConfig.java
@@ -1,0 +1,15 @@
+package com.example.pubsubclient;
+
+/**
+ * Configuration for {@link PollingConsumer}. Encapsulates all parameters
+ * required to start periodic event polling.
+ */
+public record PollingConsumerConfig(
+        PubSubClient client,
+        String org,
+        String topic,
+        String subscription,
+        int batchSize,
+        long intervalMillis,
+        EventsHandler handler
+) {}

--- a/src/main/java/com/example/pubsubclient/PubSubClient.java
+++ b/src/main/java/com/example/pubsubclient/PubSubClient.java
@@ -1,0 +1,139 @@
+package com.example.pubsubclient;
+
+import com.example.pubsubclient.model.*;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Function;
+
+public class PubSubClient {
+    private final String baseUrl;
+    private final HttpClient httpClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public PubSubClient(String baseUrl) {
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    public void createOrganization(String name) throws IOException, InterruptedException {
+        Map<String, String> body = Map.of("name", name);
+        send(HttpRequest.newBuilder(URI.create(baseUrl + "/orgs"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build());
+    }
+
+    public Optional<UUID> getOrganizationId(String orgName) throws IOException, InterruptedException {
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(URI.create(baseUrl + "/orgs/" + orgName)).GET().build());
+        if (resp.statusCode() == 404) {
+            return Optional.empty();
+        }
+        return Optional.of(UUID.fromString(resp.body().replace("\"", "")));
+    }
+
+    public void deleteOrganization(String orgName) throws IOException, InterruptedException {
+        send(HttpRequest.newBuilder(URI.create(baseUrl + "/orgs/" + orgName)).DELETE().build());
+    }
+
+    public void createTopic(String orgName, String topicName) throws IOException, InterruptedException {
+        Map<String, String> body = Map.of("name", topicName);
+        send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build());
+    }
+
+    public Topic getTopic(String orgName, String topicName) throws IOException, InterruptedException {
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics/" + topicName)).GET().build());
+        if (resp.statusCode() == 404) {
+            throw new RuntimeException("Topic or organization not found");
+        }
+        return mapper.readValue(resp.body(), Topic.class);
+    }
+
+    public void deleteTopic(String orgName, String topicName) throws IOException, InterruptedException {
+        send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics/" + topicName)).DELETE().build());
+    }
+
+    public void createSubscription(String orgName, String topicName, String subscriptionName) throws IOException, InterruptedException {
+        Map<String, String> body = Map.of("name", subscriptionName);
+        send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics/" + topicName + "/subscriptions"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build());
+    }
+
+    public Subscription getSubscription(String orgName, String topicName, String subscriptionName) throws IOException, InterruptedException {
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics/" + topicName + "/subscriptions/" + subscriptionName)).GET().build());
+        if (resp.statusCode() == 404) {
+            throw new RuntimeException("Subscription, topic or organization not found");
+        }
+        return mapper.readValue(resp.body(), Subscription.class);
+    }
+
+    public void deleteSubscription(String orgName, String topicName, String subscriptionName) throws IOException, InterruptedException {
+        send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics/" + topicName + "/subscriptions/" + subscriptionName)).DELETE().build());
+    }
+
+    public int publishEvents(String orgName, String topicName, List<EventPublishRequest<?>> events) throws IOException, InterruptedException {
+        String body = mapper.writeValueAsString(events);
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(URI.create(baseUrl + "/" + orgName + "/topics/" + topicName + "/events"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build());
+        return Integer.parseInt(resp.body());
+    }
+
+    public List<EventResponse> readEvents(String orgName, String topicName, String subscriptionName, int batchSize) throws IOException, InterruptedException {
+        String url = String.format("%s/%s/topics/%s/subscriptions/%s/events?batchSize=%d", baseUrl, orgName, topicName, subscriptionName, batchSize);
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(URI.create(url)).GET().build());
+        if (resp.statusCode() == 204) {
+            return List.of();
+        }
+        if (resp.statusCode() == 404) {
+            throw new RuntimeException("Subscription, topic or organization not found");
+        }
+        return mapper.readValue(resp.body(), new TypeReference<List<EventResponse>>() {});
+    }
+
+    public int commitEvents(String orgName, String topicName, String subscriptionName, List<UUID> eventIds) throws IOException, InterruptedException {
+        String url = String.format("%s/%s/topics/%s/subscriptions/%s/events", baseUrl, orgName, topicName, subscriptionName);
+        String body = mapper.writeValueAsString(eventIds);
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build());
+        return Integer.parseInt(resp.body());
+    }
+
+    public void consumeEvents(String org, String topic, String sub, int batchSize, EventsHandler handler) throws Exception {
+        List<EventResponse> events = readEvents(org, topic, sub, batchSize);
+        if (events.isEmpty()) {
+            return;
+        }
+        Function<List<UUID>, Integer> commitFn = ids -> {
+            try {
+                return commitEvents(org, topic, sub, ids);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+        handler.handle(events, commitFn);
+    }
+
+    private HttpResponse<String> send(HttpRequest request) throws IOException, InterruptedException {
+        HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 400) {
+            throw new RuntimeException("Request failed with status code " + resp.statusCode());
+        }
+        return resp;
+    }
+}

--- a/src/main/java/com/example/pubsubclient/model/EventPublishRequest.java
+++ b/src/main/java/com/example/pubsubclient/model/EventPublishRequest.java
@@ -1,0 +1,9 @@
+package com.example.pubsubclient.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wrapper for publishing events. The data payload is a generic type that will
+ * be serialized to JSON when sent to the pub-sub-service.
+ */
+public record EventPublishRequest<T>(@JsonProperty("data") T data) {}

--- a/src/main/java/com/example/pubsubclient/model/EventResponse.java
+++ b/src/main/java/com/example/pubsubclient/model/EventResponse.java
@@ -1,0 +1,13 @@
+package com.example.pubsubclient.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record EventResponse(
+        UUID id,
+        @JsonProperty("data") Object data,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssX") Instant createdAt
+) {}

--- a/src/main/java/com/example/pubsubclient/model/Subscription.java
+++ b/src/main/java/com/example/pubsubclient/model/Subscription.java
@@ -1,0 +1,5 @@
+package com.example.pubsubclient.model;
+
+import java.util.UUID;
+
+public record Subscription(UUID id, String name, UUID topicId) {}

--- a/src/main/java/com/example/pubsubclient/model/Topic.java
+++ b/src/main/java/com/example/pubsubclient/model/Topic.java
@@ -1,0 +1,5 @@
+package com.example.pubsubclient.model;
+
+import java.util.UUID;
+
+public record Topic(UUID id, String name, UUID organizationId) {}

--- a/src/test/java/com/example/pubsubclient/PubSubClientTest.java
+++ b/src/test/java/com/example/pubsubclient/PubSubClientTest.java
@@ -1,0 +1,117 @@
+package com.example.pubsubclient;
+
+import com.example.pubsubclient.model.EventResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PubSubClientTest {
+    private HttpServer server;
+    private String baseUrl;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    void setup() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterAll
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void testGetOrganizationId() throws Exception {
+        UUID orgId = UUID.randomUUID();
+        server.createContext("/orgs/test", exchange -> {
+            sendJson(exchange, 200, '"' + orgId.toString() + '"');
+        });
+        PubSubClient client = new PubSubClient(baseUrl);
+        Optional<UUID> result = client.getOrganizationId("test");
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(orgId, result.get());
+    }
+
+    @Test
+    void testConsumeEvents() throws Exception {
+        server.createContext("/org/topics/topic/subscriptions/sub/events", exchange -> {
+            if (exchange.getRequestMethod().equals("GET")) {
+                List<EventResponse> events = List.of(
+                        new EventResponse(UUID.randomUUID(), Map.of("message", "hello"), Instant.now())
+                );
+                sendJson(exchange, 200, mapper.writeValueAsString(events));
+            } else if (exchange.getRequestMethod().equals("POST")) {
+                sendJson(exchange, 200, "1");
+            }
+        });
+        PubSubClient client = new PubSubClient(baseUrl);
+        client.consumeEvents("org", "topic", "sub", 10, (events, commit) -> {
+            Assertions.assertFalse(events.isEmpty());
+            int committed = commit.apply(List.of(events.getFirst().id()));
+            Assertions.assertEquals(1, committed);
+        });
+    }
+
+    @Test
+    void testPollingConsumer() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        server.createContext("/org/topics/topic/subscriptions/sub2/events", exchange -> {
+            if (exchange.getRequestMethod().equals("GET")) {
+                calls.incrementAndGet();
+                List<EventResponse> events = List.of(
+                        new EventResponse(UUID.randomUUID(), Map.of("msg", "x"), Instant.now())
+                );
+                sendJson(exchange, 200, mapper.writeValueAsString(events));
+            } else if (exchange.getRequestMethod().equals("POST")) {
+                sendJson(exchange, 200, "1");
+            }
+        });
+
+        PubSubClient client = new PubSubClient(baseUrl);
+        EventsHandler handler = (events, commit) -> commit.apply(List.of(events.getFirst().id()));
+        PollingConsumerConfig cfg = new PollingConsumerConfig(
+                client,
+                "org",
+                "topic",
+                "sub2",
+                1,
+                100L,
+                handler);
+        try (PollingConsumer consumer = new PollingConsumer(cfg)) {
+            consumer.start();
+            Thread.sleep(250);
+        }
+
+        Assertions.assertTrue(calls.get() >= 2);
+    }
+
+    private void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+        // fully consume the request body to avoid connection reset issues
+        exchange.getRequestBody().readAllBytes();
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, body.getBytes().length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body.getBytes());
+        }
+        exchange.close();
+    }
+}


### PR DESCRIPTION
## Summary
- extract PollingConsumer parameters into `PollingConsumerConfig`
- update `PollingConsumer` and README to use the new config
- provide a commit function when consuming events
- improve test HTTP server helper to avoid connection resets

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861ea430c5c832d89377a9c3ccd5aee